### PR TITLE
commentcounter takes 0 into account

### DIFF
--- a/src/modules/__test__/commentCounter.test.js
+++ b/src/modules/__test__/commentCounter.test.js
@@ -15,7 +15,7 @@ test('commentCounter should update comment title with correct number of comments
 test('commentCounter should update comment title if data is empty', () => {
   const data = [];
   commentCounter(data);
-  expect(document.querySelector('.commentNumber').innerHTML).toBe(`Comments (0)`);
+  expect(document.querySelector('.commentNumber').innerHTML).toBe('Comments (0)');
 });
 
 // Edge test case

--- a/src/modules/__test__/commentCounter.test.js
+++ b/src/modules/__test__/commentCounter.test.js
@@ -15,7 +15,7 @@ test('commentCounter should update comment title with correct number of comments
 test('commentCounter should update comment title if data is empty', () => {
   const data = [];
   commentCounter(data);
-  expect(document.querySelector('.commentNumber').innerHTML).toBe(`Comments (${data.length})`);
+  expect(document.querySelector('.commentNumber').innerHTML).toBe(`Comments (0)`);
 });
 
 // Edge test case


### PR DESCRIPTION
## In this branch:

 - I change one line of the commentCounter tests so that the number 0 appears.
 - This is only so that reviewers that can't read can realize that there is in fact a case 0 test.